### PR TITLE
Relax descarteslabs package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup_args = dict(
     packages=setuptools.find_packages(),
     entry_points={"console_scripts": ["voila = voila.app:main"]},
     install_requires=[
-        "descarteslabs==1.7.1",
+        "descarteslabs>=1.7.1",
         "jupyter_server>=0.3.0,<2.0.0",
         "jupyter_client>=6.1.3,<7",
         "nbclient>=0.4.0,<0.6",


### PR DESCRIPTION
This relaxes the version of the `descarteslabs` package used by Voila.