### PR TITLE
Revert to using /app as endpoint

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -513,7 +513,7 @@ class Voila(Application):
         }
         if self.notebook_path:
             handlers.append((
-                url_path_join(self.server_url, r'/(.*)'),
+                url_path_join(self.server_url, r'/app'),
                 VoilaHandler,
                 {
                     'notebook_path': os.path.relpath(self.notebook_path, self.root_dir),
@@ -540,6 +540,14 @@ class Voila(Application):
                  }),
             ])
 
+        handlers.append((
+            url_path_join(self.server_url, r'/(.*)'),
+            MultiStaticFileHandler,
+            {
+                'paths': self.static_paths,
+                'default_filename': 'index.html'
+            },
+        ))
         self.app.add_handlers('.*$', handlers)
         self.listen()
 


### PR DESCRIPTION
This reverts to using `/app` as the application endpoint.